### PR TITLE
refact: enhance progress bar and plot aspect ratio

### DIFF
--- a/opstool/anlys/_smart_analyze.py
+++ b/opstool/anlys/_smart_analyze.py
@@ -352,7 +352,7 @@ class SmartAnalyze:
     def _set_progress_bar(self, npts):
         self.progress = tqdm(
             total=npts,
-            desc=self.logo_progress,
+            desc=f"🚀 {self.logo_progress}",
             colour="#5170d7",
             unit=" step",
         )

--- a/opstool/pre/section/sec_mesh.py
+++ b/opstool/pre/section/sec_mesh.py
@@ -1799,7 +1799,7 @@ class FiberSecMesh:
                 rebar_colors.append(color)
                 ax.plot([], [], "o", label=name, color=color)
 
-        ax.set_aspect(aspect_ratio)
+        ax.set_aspect(aspect_ratio, adjustable='datalim')
         ax.set_title(self.sec_name, fontsize=16)
         if show_legend:
             ax.legend(


### PR DESCRIPTION
1. In the last pull request i forgot 🚀
2. compare `adjustable='datalim'`
before
<img width="865" height="1377" alt="before" src="https://github.com/user-attachments/assets/a0b30c56-6b83-4496-a73c-4af37910d3fa" />
after
<img width="959" height="1341" alt="after" src="https://github.com/user-attachments/assets/185aed08-0ef2-48cc-b6fd-d1c2c6ad6d43" />
